### PR TITLE
Mariana_Graph.tsx

### DIFF
--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -14,7 +14,7 @@ interface IProps {
  * Perspective library adds load to HTMLElement prototype.
  * This interface acts as a wrapper for Typescript compiler.
  */
-interface PerspectiveViewerElement {
+interface PerspectiveViewerElement extends HTMLElement {
   load: (table: Table) => void,
 }
 
@@ -32,7 +32,7 @@ class Graph extends Component<IProps, {}> {
 
   componentDidMount() {
     // Get element to attach the table from the DOM.
-    const elem: PerspectiveViewerElement = document.getElementsByTagName('perspective-viewer')[0] as unknown as PerspectiveViewerElement;
+    const elem = document.getElementsByTagName('perspective-viewer')[0] as unknown as PerspectiveViewerElement;
 
     const schema = {
       stock: 'string',
@@ -49,6 +49,16 @@ class Graph extends Component<IProps, {}> {
 
       // Add more Perspective configurations here.
       elem.load(this.table);
+      elem.setAttribute('view', 'y_line');
+      elem.setAttribute('column-pivots', '["stock"]');
+      elem.setAttribute('row-pivots', '["timestamp"]');
+      elem.setAttribute('columns', '["top_ask_price"]');
+      elem.setAttribute('aggregates',
+        {"stock":"distinct count",
+        "top_ask_price":"avg",
+        "top_bid_price":"avg",
+        "timestamp":"distinct count"}');
+                         
     }
   }
 


### PR DESCRIPTION
First, you must enable the `PerspectiveViewerElement` to behave like an
HTMLElement. To do this, you can extend the `HTMLElement` class from the`PerspectiveViewerElement` interface.
Since you’ve changed the `PerspectiveViewerElement` to extend the
`HTMLElement` earlier, you can now make the definition of the `const elem`
simpler, i.e. you can just assign it straight to the result of the
`document.getElementsByTagName`. 
Finally, you need to add more attributes to the element. For this you have to
have read thru the Perspective configurations particularly on the table.view
configurations. You’ll need to add the following attributes: `view`,
`column-pivots`, `row-pivots`, `columns` and `aggregates` . If you
remember the earlier observations we did in the earlier slides, this is the
configurable part of the table/graph.